### PR TITLE
Add timestamp count slider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
+pnpm-lock.yaml
 
 # env files (can opt-in for committing if needed)
 .env*

--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -73,7 +73,13 @@ export async function POST(request: Request) {
       );
     }
 
-    const { srtContent } = validationResult.data;
+    const { srtContent, timestampCount } = validationResult.data;
+
+    let timestampInstruction =
+      "Aim for a range of 5-12 timestamps for the entire video.";
+    if (typeof timestampCount === "number") {
+      timestampInstruction = `Aim for roughly ${timestampCount} timestamps for the entire video.`;
+    }
 
     // Extract the last timestamp from the SRT content using a more robust pattern
     // This looks for SRT timestamp patterns like "00:14:03,251 --> 00:14:03,751"
@@ -138,7 +144,7 @@ MM:SS [Specific final topic]
 
 1. **Video Length:** The video length is ${maxTimestamp}. Do not generate any timestamps beyond ${maxTimestamp} under any circumstances.
 
-2. **Target Timestamp Quantity:** (Crucial Adjustment) Aim for a more manageable number of timestamps, aiming for a range of **5-12 timestamps** for the entire video, regardless of length. This is crucial for conciseness and to prevent an overly long list. Don't be afraid to be more selective.
+2. **Target Timestamp Quantity:** (Crucial Adjustment) ${timestampInstruction} This is crucial for conciseness and to prevent an overly long list. Don't be afraid to be more selective.
 
 3. **Content Analysis:** Analyze the transcript to identify major themes, demonstrations, and transitions. Focus on:
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,6 +19,7 @@ export default function Home() {
   const [isProcessing, setIsProcessing] = useState(false);
   const [generatedContent, setGeneratedContent] = useState<string>("");
   const [error, setError] = useState<string>("");
+  const [timestampCount, setTimestampCount] = useState<number>(8);
 
   // Handle extracted SRT content
   const handleContentExtracted = (content: string, entries: SrtEntry[]) => {
@@ -68,7 +69,7 @@ export default function Home() {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ srtContent }),
+        body: JSON.stringify({ srtContent, timestampCount }),
       });
 
       if (!response.ok) {
@@ -209,6 +210,8 @@ export default function Home() {
               disabled={isProcessing}
               entriesCount={srtEntries.length}
               hasContent={!!srtContent}
+              timestampCount={timestampCount}
+              onTimestampCountChange={setTimestampCount}
             />
           )}
 

--- a/components/SrtUploader.tsx
+++ b/components/SrtUploader.tsx
@@ -1,7 +1,11 @@
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { MAX_FILE_SIZE } from "@/lib/constants";
+import {
+  MAX_FILE_SIZE,
+  MIN_TIMESTAMP_COUNT,
+  MAX_TIMESTAMP_COUNT,
+} from "@/lib/constants";
 import { srtFileSchema } from "@/lib/schemas";
 import { extractTextFromSrt, parseSrtContent, SrtEntry } from "@/lib/srt-parser";
 import { useRef, useState } from "react";
@@ -12,6 +16,8 @@ interface SrtUploaderProps {
   disabled: boolean;
   entriesCount: number;
   hasContent: boolean;
+  timestampCount: number;
+  onTimestampCountChange: (count: number) => void;
 }
 
 export function SrtUploader({
@@ -20,6 +26,8 @@ export function SrtUploader({
   disabled,
   entriesCount,
   hasContent,
+  timestampCount,
+  onTimestampCountChange,
 }: SrtUploaderProps) {
   const [fileName, setFileName] = useState<string>("");
   const [error, setError] = useState<string>("");
@@ -198,6 +206,29 @@ export function SrtUploader({
             <p className="text-sm text-sky-600 dark:text-sky-400 bg-sky-50/50 dark:bg-sky-900/20 px-4 py-2 rounded-full border border-sky-100/70 dark:border-sky-800/50">
               <span className="font-medium">{entriesCount}</span> entries found in the SRT file
             </p>
+            <div className="w-full max-w-xs flex flex-col gap-2">
+              <label htmlFor="timestampCount" className="sr-only">
+                Timestamp count
+              </label>
+              <input
+                type="range"
+                id="timestampCount"
+                min={MIN_TIMESTAMP_COUNT}
+                max={MAX_TIMESTAMP_COUNT}
+                value={timestampCount}
+                onChange={(e) => onTimestampCountChange(Number(e.target.value))}
+                className="w-full"
+              />
+              <input
+                type="number"
+                id="timestampCountInput"
+                min={MIN_TIMESTAMP_COUNT}
+                max={MAX_TIMESTAMP_COUNT}
+                value={timestampCount}
+                onChange={(e) => onTimestampCountChange(Number(e.target.value))}
+                className="w-full rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-1 text-sm text-center"
+              />
+            </div>
             <Button
               onClick={onProcessFile}
               className="w-full max-w-xs"

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -4,3 +4,7 @@
 
 // Max file size in bytes (420 KB)
 export const MAX_FILE_SIZE = 420 * 1024;
+
+// Default timestamp count settings
+export const MIN_TIMESTAMP_COUNT = 3;
+export const MAX_TIMESTAMP_COUNT = 20;

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
-import { MAX_FILE_SIZE } from "./constants";
+import {
+  MAX_FILE_SIZE,
+  MIN_TIMESTAMP_COUNT,
+  MAX_TIMESTAMP_COUNT,
+} from "./constants";
 
 // SRT Entry schema for validating individual entries
 export const srtEntrySchema = z.object({
@@ -31,7 +35,16 @@ export const generateApiRequestSchema = z.object({
   srtContent: z
     .string()
     .min(1, "SRT content is required")
-    .max(MAX_FILE_SIZE, `SRT content is too large. Maximum size is ${MAX_FILE_SIZE / 1024}KB`),
+    .max(
+      MAX_FILE_SIZE,
+      `SRT content is too large. Maximum size is ${MAX_FILE_SIZE / 1024}KB`
+    ),
+  timestampCount: z
+    .number()
+    .int()
+    .min(MIN_TIMESTAMP_COUNT)
+    .max(MAX_TIMESTAMP_COUNT)
+    .optional(),
 });
 
 // SRT Entries array schema


### PR DESCRIPTION
## Summary
- allow custom timestamp count via API request `timestampCount`
- update prompt logic to use user provided count
- replace granularity dropdown with slider and number input
- use constants for min and max timestamp count

## Testing
- `bun lint`