### PR TITLE
Add styled select for timestamp granularity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
+pnpm-lock.yaml
 
 # env files (can opt-in for committing if needed)
 .env*

--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -73,7 +73,15 @@ export async function POST(request: Request) {
       );
     }
 
-    const { srtContent } = validationResult.data;
+    const { srtContent, granularity } = validationResult.data;
+
+    const granularitySetting = granularity ?? "default";
+    let timestampRange = "5-12";
+    if (granularitySetting === "fewer") {
+      timestampRange = "3-6";
+    } else if (granularitySetting === "more") {
+      timestampRange = "10-20";
+    }
 
     // Extract the last timestamp from the SRT content using a more robust pattern
     // This looks for SRT timestamp patterns like "00:14:03,251 --> 00:14:03,751"
@@ -138,7 +146,7 @@ MM:SS [Specific final topic]
 
 1. **Video Length:** The video length is ${maxTimestamp}. Do not generate any timestamps beyond ${maxTimestamp} under any circumstances.
 
-2. **Target Timestamp Quantity:** (Crucial Adjustment) Aim for a more manageable number of timestamps, aiming for a range of **5-12 timestamps** for the entire video, regardless of length. This is crucial for conciseness and to prevent an overly long list. Don't be afraid to be more selective.
+2. **Target Timestamp Quantity:** (Crucial Adjustment) Aim for a more manageable number of timestamps, aiming for a range of **${timestampRange} timestamps** for the entire video, regardless of length. This is crucial for conciseness and to prevent an overly long list. Don't be afraid to be more selective.
 
 3. **Content Analysis:** Analyze the transcript to identify major themes, demonstrations, and transitions. Focus on:
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,6 +19,9 @@ export default function Home() {
   const [isProcessing, setIsProcessing] = useState(false);
   const [generatedContent, setGeneratedContent] = useState<string>("");
   const [error, setError] = useState<string>("");
+  const [granularity, setGranularity] = useState<"fewer" | "default" | "more">(
+    "default"
+  );
 
   // Handle extracted SRT content
   const handleContentExtracted = (content: string, entries: SrtEntry[]) => {
@@ -68,7 +71,7 @@ export default function Home() {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ srtContent }),
+        body: JSON.stringify({ srtContent, granularity }),
       });
 
       if (!response.ok) {
@@ -209,6 +212,8 @@ export default function Home() {
               disabled={isProcessing}
               entriesCount={srtEntries.length}
               hasContent={!!srtContent}
+              granularity={granularity}
+              onGranularityChange={setGranularity}
             />
           )}
 

--- a/components/SrtUploader.tsx
+++ b/components/SrtUploader.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
 import { MAX_FILE_SIZE } from "@/lib/constants";
 import { srtFileSchema } from "@/lib/schemas";
 import { extractTextFromSrt, parseSrtContent, SrtEntry } from "@/lib/srt-parser";
@@ -12,6 +13,8 @@ interface SrtUploaderProps {
   disabled: boolean;
   entriesCount: number;
   hasContent: boolean;
+  granularity: "fewer" | "default" | "more";
+  onGranularityChange: (g: "fewer" | "default" | "more") => void;
 }
 
 export function SrtUploader({
@@ -20,6 +23,8 @@ export function SrtUploader({
   disabled,
   entriesCount,
   hasContent,
+  granularity,
+  onGranularityChange,
 }: SrtUploaderProps) {
   const [fileName, setFileName] = useState<string>("");
   const [error, setError] = useState<string>("");
@@ -198,6 +203,23 @@ export function SrtUploader({
             <p className="text-sm text-sky-600 dark:text-sky-400 bg-sky-50/50 dark:bg-sky-900/20 px-4 py-2 rounded-full border border-sky-100/70 dark:border-sky-800/50">
               <span className="font-medium">{entriesCount}</span> entries found in the SRT file
             </p>
+            <div className="w-full max-w-xs">
+              <label htmlFor="granularity" className="sr-only">
+                Timestamp detail
+              </label>
+              <Select
+                id="granularity"
+                value={granularity}
+                onChange={(e) =>
+                  onGranularityChange(e.target.value as "fewer" | "default" | "more")
+                }
+                className="w-full"
+              >
+                <option value="fewer">Fewer timestamps</option>
+                <option value="default">Balanced</option>
+                <option value="more">More timestamps</option>
+              </Select>
+            </div>
             <Button
               onClick={onProcessFile}
               className="w-full max-w-xs"

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement>;
+
+export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <select
+        ref={ref}
+        data-slot="select"
+        className={cn(
+          "border-slate-200/80 dark:border-slate-700/80 placeholder:text-sky-500/40 dark:placeholder:text-sky-400/30 selection:bg-emerald-200/30 dark:selection:bg-emerald-800/30 selection:text-emerald-800 dark:selection:text-emerald-100 bg-white/80 dark:bg-slate-900/50 backdrop-blur-sm flex h-10 w-full min-w-0 rounded-2xl border px-4 py-2 text-base shadow-[0_2px_10px_rgba(0,0,0,0.03)] dark:shadow-[0_2px_10px_rgba(0,0,0,0.08)] transition-all duration-200 outline-none focus-visible:border-sky-300 dark:focus-visible:border-sky-600 focus-visible:ring-sky-200/50 dark:focus-visible:ring-sky-800/30 focus-visible:ring-[3px] focus-visible:shadow-[0_4px_15px_rgba(14,165,233,0.15)] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </select>
+    );
+  }
+);
+Select.displayName = "Select";

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -31,7 +31,11 @@ export const generateApiRequestSchema = z.object({
   srtContent: z
     .string()
     .min(1, "SRT content is required")
-    .max(MAX_FILE_SIZE, `SRT content is too large. Maximum size is ${MAX_FILE_SIZE / 1024}KB`),
+    .max(
+      MAX_FILE_SIZE,
+      `SRT content is too large. Maximum size is ${MAX_FILE_SIZE / 1024}KB`
+    ),
+  granularity: z.enum(["fewer", "default", "more"]).optional(),
 });
 
 // SRT Entries array schema


### PR DESCRIPTION
## Summary
- add custom `Select` component styled like other shadcn inputs
- replace plain `<select>` in `SrtUploader` with new component
- continue to send selected granularity to the API

## Testing
- `bun lint`
